### PR TITLE
Use the Tenant models' getTenantKeyName() value

### DIFF
--- a/src/Tenancy.php
+++ b/src/Tenancy.php
@@ -80,7 +80,7 @@ class Tenancy
 
     public function find($id): ?Tenant
     {
-        return $this->model()->find($id);
+        return $this->model()->where($this->model()->getTenantKeyName(), $id)->first();
     }
 
     /**


### PR DESCRIPTION
Don't assume the Tenant can be found with the `id` attribute. The Tenant model allows for setting a different Tenant key name through `getTenantKeyName()`, so lets use it to find the Tenant.

This fixes an issue when people set their own Tenant identifier with `getTenantKeyName()`.